### PR TITLE
Implement UpdateTeasAvailability.

### DIFF
--- a/src/main/java/cz/dusanrychnovsky/myteacollection/db/TeaRepository.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/db/TeaRepository.java
@@ -1,6 +1,13 @@
 package cz.dusanrychnovsky.myteacollection.db;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeaRepository extends JpaRepository<TeaEntity, Long> {
+
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("UPDATE TeaEntity t SET t.inStock = :inStock WHERE t.id = :id")
+  int updateInStock(@Param("id") Long id, @Param("inStock") boolean inStock);
 }

--- a/src/main/java/cz/dusanrychnovsky/myteacollection/db/TeaRepository.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/db/TeaRepository.java
@@ -1,5 +1,7 @@
 package cz.dusanrychnovsky.myteacollection.db;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +12,12 @@ public interface TeaRepository extends JpaRepository<TeaEntity, Long> {
   @Modifying(flushAutomatically = true, clearAutomatically = true)
   @Query("UPDATE TeaEntity t SET t.inStock = :inStock WHERE t.id = :id")
   int updateInStock(@Param("id") Long id, @Param("inStock") boolean inStock);
+
+  @Query("SELECT t.id AS id, t.inStock AS inStock FROM TeaEntity t")
+  List<TeaAvailability> findAllAvailability();
+
+  interface TeaAvailability {
+    Long getId();
+    boolean isInStock();
+  }
 }

--- a/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/TeaRecord.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/TeaRecord.java
@@ -9,7 +9,6 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -39,7 +38,7 @@ public class TeaRecord {
   private Set<String> tags;
 
   @JsonIgnore
-  private List<BufferedImage> images;
+  private File sourceDir;
 
   @JsonCreator
   public TeaRecord(
@@ -72,8 +71,6 @@ public class TeaRecord {
     this.brewingInstructions = brewingInstructions;
     this.inStock = inStock;
     this.tags = tags != null ? tags : emptySet();
-
-    images = new ArrayList<>();
   }
 
   public static List<TeaRecord> loadNewFrom(File rootDir, long minId) {
@@ -92,13 +89,15 @@ public class TeaRecord {
   public static TeaRecord loadFrom(File dir) {
     var tea = loadInfo(new File(dir, INFO_FILE_NAME));
     tea.setId(parseLong(dir.getName()));
-    for (var file : dir.listFiles()) {
-      if (file.getName().equals(INFO_FILE_NAME)) {
-        continue;
-      }
-      tea.images.add(loadImg(file));
-    }
+    tea.sourceDir = dir;
     return tea;
+  }
+
+  public List<BufferedImage> loadImages() {
+    return stream(sourceDir.listFiles())
+      .filter(file -> !file.getName().equals(INFO_FILE_NAME))
+      .map(TeaRecord::loadImg)
+      .toList();
   }
 
   private static TeaRecord loadInfo(File infoFile) {
@@ -179,10 +178,6 @@ public class TeaRecord {
 
   public boolean isInStock() {
     return inStock;
-  }
-
-  public List<BufferedImage> getImages() {
-    return images;
   }
 
   public Set<String> getTags() {

--- a/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailability.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailability.java
@@ -1,0 +1,80 @@
+package cz.dusanrychnovsky.myteacollection.util.upload;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import cz.dusanrychnovsky.myteacollection.db.TeaEntity;
+import cz.dusanrychnovsky.myteacollection.db.TeaRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.transaction.annotation.Transactional;
+
+import static cz.dusanrychnovsky.myteacollection.util.upload.TeaRecord.loadAllFrom;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+@SpringBootApplication(scanBasePackages = "cz.dusanrychnovsky.myteacollection")
+public class UpdateTeasAvailability {
+
+  private static final Logger logger = LoggerFactory.getLogger(UpdateTeasAvailability.class);
+
+  private final TeaRepository teaRepository;
+
+  public static void main(String[] args) {
+    logger.info("Starting UpdateTeasAvailability.");
+    var context = SpringApplication.run(UpdateTeasAvailability.class, args);
+    var bean = context.getBean(UpdateTeasAvailability.class);
+    bean.run(new File(args[0]));
+    logger.info("UpdateTeasAvailability successfully finished.");
+  }
+
+  @Autowired
+  public UpdateTeasAvailability(TeaRepository teaRepository) {
+    this.teaRepository = teaRepository;
+  }
+
+  @Transactional
+  public void run(File rootDir) {
+    logger.info("Going to update tea availability from dir: {}.", rootDir);
+
+    var records = loadAllFrom(rootDir);
+    logger.info("Loaded {} tea records from disk.", records.size());
+
+    logger.info("Going to fetch teas from db.");
+    var teasById = teaRepository.findAll().stream()
+      .collect(toMap(TeaEntity::getId, identity()));
+
+    var updates = computeUpdates(records, teasById);
+
+    for (var update : updates) {
+      logger.info("Going to update tea: #{} -> inStock={}", update.id(), update.newInStock());
+      teaRepository.updateInStock(update.id(), update.newInStock());
+    }
+
+    logger.info("Update finished. Checked {} teas, updated {}.", records.size(), updates.size());
+  }
+
+  static List<AvailabilityUpdate> computeUpdates(
+    List<TeaRecord> records,
+    Map<Long, TeaEntity> teasById) {
+
+    var updates = new ArrayList<AvailabilityUpdate>();
+    for (var record : records) {
+      var entity = teasById.get(record.getId());
+      if (entity == null) {
+        throw new IllegalStateException("No tea in db for id: " + record.getId());
+      }
+      if (record.isInStock() != entity.isInStock()) {
+        updates.add(new AvailabilityUpdate(record.getId(), record.isInStock()));
+      }
+    }
+    return updates;
+  }
+
+  public record AvailabilityUpdate(long id, boolean newInStock) {}
+}

--- a/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailability.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailability.java
@@ -1,7 +1,7 @@
 package cz.dusanrychnovsky.myteacollection.util.upload;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,30 +51,28 @@ public class UpdateTeasAvailability {
 
     var updates = computeUpdates(records, teasById);
 
-    for (var update : updates) {
-      logger.info("Going to update tea: #{} -> inStock={}", update.id(), update.newInStock());
-      teaRepository.updateInStock(update.id(), update.newInStock());
+    for (var update : updates.entrySet()) {
+      logger.info("Going to update tea: #{} -> inStock={}", update.getKey(), update.getValue());
+      teaRepository.updateInStock(update.getKey(), update.getValue());
     }
 
     logger.info("Update finished. Checked {} teas, updated {}.", records.size(), updates.size());
   }
 
-  static List<AvailabilityUpdate> computeUpdates(
+  static Map<Long, Boolean> computeUpdates(
     List<TeaRecord> records,
     Map<Long, TeaEntity> teasById) {
 
-    var updates = new ArrayList<AvailabilityUpdate>();
+    var updates = new LinkedHashMap<Long, Boolean>();
     for (var record : records) {
       var entity = teasById.get(record.getId());
       if (entity == null) {
         throw new IllegalStateException("No tea in db for id: " + record.getId());
       }
       if (record.isInStock() != entity.isInStock()) {
-        updates.add(new AvailabilityUpdate(record.getId(), record.isInStock()));
+        updates.put(record.getId(), record.isInStock());
       }
     }
     return updates;
   }
-
-  public record AvailabilityUpdate(long id, boolean newInStock) {}
 }

--- a/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailability.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailability.java
@@ -5,8 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import cz.dusanrychnovsky.myteacollection.db.TeaEntity;
 import cz.dusanrychnovsky.myteacollection.db.TeaRepository;
+import cz.dusanrychnovsky.myteacollection.db.TeaRepository.TeaAvailability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +15,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.transaction.annotation.Transactional;
 
 import static cz.dusanrychnovsky.myteacollection.util.upload.TeaRecord.loadAllFrom;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 @SpringBootApplication(scanBasePackages = "cz.dusanrychnovsky.myteacollection")
@@ -46,10 +45,10 @@ public class UpdateTeasAvailability {
     logger.info("Loaded {} tea records from disk.", records.size());
 
     logger.info("Going to fetch teas from db.");
-    var teasById = teaRepository.findAll().stream()
-      .collect(toMap(TeaEntity::getId, identity()));
+    var dbInStockById = teaRepository.findAllAvailability().stream()
+      .collect(toMap(TeaAvailability::getId, TeaAvailability::isInStock));
 
-    var updates = computeUpdates(records, teasById);
+    var updates = computeUpdates(records, dbInStockById);
 
     for (var update : updates.entrySet()) {
       logger.info("Going to update tea: #{} -> inStock={}", update.getKey(), update.getValue());
@@ -61,15 +60,15 @@ public class UpdateTeasAvailability {
 
   static Map<Long, Boolean> computeUpdates(
     List<TeaRecord> records,
-    Map<Long, TeaEntity> teasById) {
+    Map<Long, Boolean> dbInStockById) {
 
     var updates = new LinkedHashMap<Long, Boolean>();
     for (var record : records) {
-      var entity = teasById.get(record.getId());
-      if (entity == null) {
+      var dbInStock = dbInStockById.get(record.getId());
+      if (dbInStock == null) {
         throw new IllegalStateException("No tea in db for id: " + record.getId());
       }
-      if (record.isInStock() != entity.isInStock()) {
+      if (record.isInStock() != dbInStock) {
         updates.put(record.getId(), record.isInStock());
       }
     }

--- a/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UploadNewTeas.java
+++ b/src/main/java/cz/dusanrychnovsky/myteacollection/util/upload/UploadNewTeas.java
@@ -89,7 +89,7 @@ public class UploadNewTeas {
 
       var idx = 0;
       // TODO: load tea images in correct order
-      for (var image : tea.getImages()) {
+      for (var image : tea.loadImages()) {
         idx++;
         logger.info("Going to upload image: #{}", idx);
 

--- a/src/test/java/cz/dusanrychnovsky/myteacollection/integration/UpdateTeasAvailabilityIT.java
+++ b/src/test/java/cz/dusanrychnovsky/myteacollection/integration/UpdateTeasAvailabilityIT.java
@@ -1,0 +1,54 @@
+package cz.dusanrychnovsky.myteacollection.integration;
+
+import cz.dusanrychnovsky.myteacollection.db.TeaEntity;
+import cz.dusanrychnovsky.myteacollection.db.TeaRepository;
+import cz.dusanrychnovsky.myteacollection.util.upload.UpdateTeasAvailability;
+import cz.dusanrychnovsky.myteacollection.util.upload.UploadNewTeas;
+import cz.dusanrychnovsky.myteacollection.util.users.CreateUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+import static cz.dusanrychnovsky.myteacollection.util.ClassLoaderUtils.toFile;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.properties")
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+class UpdateTeasAvailabilityIT {
+
+  @Autowired
+  private CreateUser createUser;
+
+  @Autowired
+  private UploadNewTeas uploadNewTeas;
+
+  @Autowired
+  private UpdateTeasAvailability updateTeasAvailability;
+
+  @Autowired
+  private TeaRepository teaRepository;
+
+  @Transactional
+  @Test
+  void updatesOnlyTeasWithDivergingAvailability() throws IOException {
+    createUser.run(UploadNewTeas.USER_EMAIL, "pwd", "Dušan", "Rychnovský");
+    uploadNewTeas.run(toFile("teas"));
+
+    var teas = teaRepository.findAll();
+    teaRepository.updateInStock(teas.get(0).getId(), false);
+    teaRepository.updateInStock(teas.get(2).getId(), false);
+
+    updateTeasAvailability.run(toFile("teas"));
+
+    assertTrue(teaRepository.findAll().stream().allMatch(TeaEntity::isInStock));
+  }
+}

--- a/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/TeaRecordTests.java
+++ b/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/TeaRecordTests.java
@@ -29,8 +29,14 @@ class TeaRecordTests {
     assertEquals("4", tea.getPrice());
     assertEquals("100°C, 5g/100ml, 15s-10s-5s-10s-20s", tea.getBrewingInstructions());
     assertTrue(tea.isInStock());
-    assertEquals(2, tea.getImages().size());
     assertEquals(Set.of("meetea-2025-jan", "meetea-2024-dec"), tea.getTags());
+  }
+
+  @Test
+  void loadImages_loadsImagesFromGivenDirectory() {
+    var tea = loadFrom(toFile("teas/01"));
+
+    assertEquals(2, tea.loadImages().size());
   }
 
   @Test

--- a/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailabilityTests.java
+++ b/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailabilityTests.java
@@ -1,0 +1,114 @@
+package cz.dusanrychnovsky.myteacollection.util.upload;
+
+import cz.dusanrychnovsky.myteacollection.db.TeaEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static cz.dusanrychnovsky.myteacollection.util.upload.UpdateTeasAvailability.AvailabilityUpdate;
+import static cz.dusanrychnovsky.myteacollection.util.upload.UpdateTeasAvailability.computeUpdates;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UpdateTeasAvailabilityTests {
+
+  @Test
+  void computeUpdates_allMatch_returnsEmpty() {
+    var records = List.of(record(1L, true), record(2L, false));
+    var teasById = Map.of(
+      1L, entity(1L, true),
+      2L, entity(2L, false));
+
+    var result = computeUpdates(records, teasById);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void computeUpdates_someDiffer_returnsOnlyDiffering() {
+    var records = List.of(record(1L, true), record(2L, false), record(3L, true));
+    var teasById = Map.of(
+      1L, entity(1L, true),    // matches
+      2L, entity(2L, true),    // differs - JSON says false
+      3L, entity(3L, true));   // matches
+
+    var result = computeUpdates(records, teasById);
+
+    assertEquals(List.of(new AvailabilityUpdate(2L, false)), result);
+  }
+
+  @Test
+  void computeUpdates_jsonTrueDbFalse_emitsTrue() {
+    var records = List.of(record(1L, true));
+    var teasById = Map.of(1L, entity(1L, false));
+
+    var result = computeUpdates(records, teasById);
+
+    assertEquals(List.of(new AvailabilityUpdate(1L, true)), result);
+  }
+
+  @Test
+  void computeUpdates_jsonFalseDbTrue_emitsFalse() {
+    var records = List.of(record(1L, false));
+    var teasById = Map.of(1L, entity(1L, true));
+
+    var result = computeUpdates(records, teasById);
+
+    assertEquals(List.of(new AvailabilityUpdate(1L, false)), result);
+  }
+
+  @Test
+  void computeUpdates_recordWithNoMatchingEntity_throws() {
+    var records = List.of(record(42L, true));
+    var teasById = Map.<Long, TeaEntity>of();
+
+    var ex = assertThrows(IllegalStateException.class, () -> computeUpdates(records, teasById));
+    assertTrue(ex.getMessage().contains("42"));
+  }
+
+  private static TeaRecord record(long id, boolean inStock) {
+    return new TeaRecord(
+      "title",
+      "name",
+      "description",
+      Set.of("Dark"),
+      "Vendor",
+      "https://example.com",
+      "origin",
+      "cultivar",
+      "season",
+      "elevation",
+      "N/A",
+      "instructions",
+      inStock,
+      Set.of()
+    ).setId(id);
+  }
+
+  private static TeaEntity entity(long id, boolean inStock) {
+    return new StubTeaEntity(id, inStock);
+  }
+
+  private static class StubTeaEntity extends TeaEntity {
+    private final long id;
+    private final boolean inStock;
+
+    StubTeaEntity(long id, boolean inStock) {
+      this.id = id;
+      this.inStock = inStock;
+    }
+
+    @Override
+    public Long getId() {
+      return id;
+    }
+
+    @Override
+    public boolean isInStock() {
+      return inStock;
+    }
+  }
+}

--- a/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailabilityTests.java
+++ b/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailabilityTests.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static cz.dusanrychnovsky.myteacollection.util.upload.UpdateTeasAvailability.AvailabilityUpdate;
 import static cz.dusanrychnovsky.myteacollection.util.upload.UpdateTeasAvailability.computeUpdates;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,13 +30,13 @@ class UpdateTeasAvailabilityTests {
   void computeUpdates_someDiffer_returnsOnlyDiffering() {
     var records = List.of(record(1L, true), record(2L, false), record(3L, true));
     var teasById = Map.of(
-      1L, entity(1L, true),    // matches
-      2L, entity(2L, true),    // differs - JSON says false
-      3L, entity(3L, true));   // matches
+      1L, entity(1L, true),
+      2L, entity(2L, true),
+      3L, entity(3L, true));
 
     var result = computeUpdates(records, teasById);
 
-    assertEquals(List.of(new AvailabilityUpdate(2L, false)), result);
+    assertEquals(Map.of(2L, false), result);
   }
 
   @Test
@@ -47,7 +46,7 @@ class UpdateTeasAvailabilityTests {
 
     var result = computeUpdates(records, teasById);
 
-    assertEquals(List.of(new AvailabilityUpdate(1L, true)), result);
+    assertEquals(Map.of(1L, true), result);
   }
 
   @Test
@@ -57,7 +56,7 @@ class UpdateTeasAvailabilityTests {
 
     var result = computeUpdates(records, teasById);
 
-    assertEquals(List.of(new AvailabilityUpdate(1L, false)), result);
+    assertEquals(Map.of(1L, false), result);
   }
 
   @Test

--- a/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailabilityTests.java
+++ b/src/test/java/cz/dusanrychnovsky/myteacollection/util/upload/UpdateTeasAvailabilityTests.java
@@ -1,6 +1,5 @@
 package cz.dusanrychnovsky.myteacollection.util.upload;
 
-import cz.dusanrychnovsky.myteacollection.db.TeaEntity;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -17,11 +16,9 @@ class UpdateTeasAvailabilityTests {
   @Test
   void computeUpdates_allMatch_returnsEmpty() {
     var records = List.of(record(1L, true), record(2L, false));
-    var teasById = Map.of(
-      1L, entity(1L, true),
-      2L, entity(2L, false));
+    var dbInStockById = Map.of(1L, true, 2L, false);
 
-    var result = computeUpdates(records, teasById);
+    var result = computeUpdates(records, dbInStockById);
 
     assertTrue(result.isEmpty());
   }
@@ -29,12 +26,12 @@ class UpdateTeasAvailabilityTests {
   @Test
   void computeUpdates_someDiffer_returnsOnlyDiffering() {
     var records = List.of(record(1L, true), record(2L, false), record(3L, true));
-    var teasById = Map.of(
-      1L, entity(1L, true),
-      2L, entity(2L, true),
-      3L, entity(3L, true));
+    var dbInStockById = Map.of(
+      1L, true,
+      2L, true,
+      3L, true);
 
-    var result = computeUpdates(records, teasById);
+    var result = computeUpdates(records, dbInStockById);
 
     assertEquals(Map.of(2L, false), result);
   }
@@ -42,9 +39,9 @@ class UpdateTeasAvailabilityTests {
   @Test
   void computeUpdates_jsonTrueDbFalse_emitsTrue() {
     var records = List.of(record(1L, true));
-    var teasById = Map.of(1L, entity(1L, false));
+    var dbInStockById = Map.of(1L, false);
 
-    var result = computeUpdates(records, teasById);
+    var result = computeUpdates(records, dbInStockById);
 
     assertEquals(Map.of(1L, true), result);
   }
@@ -52,9 +49,9 @@ class UpdateTeasAvailabilityTests {
   @Test
   void computeUpdates_jsonFalseDbTrue_emitsFalse() {
     var records = List.of(record(1L, false));
-    var teasById = Map.of(1L, entity(1L, true));
+    var dbInStockById = Map.of(1L, true);
 
-    var result = computeUpdates(records, teasById);
+    var result = computeUpdates(records, dbInStockById);
 
     assertEquals(Map.of(1L, false), result);
   }
@@ -62,9 +59,9 @@ class UpdateTeasAvailabilityTests {
   @Test
   void computeUpdates_recordWithNoMatchingEntity_throws() {
     var records = List.of(record(42L, true));
-    var teasById = Map.<Long, TeaEntity>of();
+    var dbInStockById = Map.<Long, Boolean>of();
 
-    var ex = assertThrows(IllegalStateException.class, () -> computeUpdates(records, teasById));
+    var ex = assertThrows(IllegalStateException.class, () -> computeUpdates(records, dbInStockById));
     assertTrue(ex.getMessage().contains("42"));
   }
 
@@ -73,41 +70,17 @@ class UpdateTeasAvailabilityTests {
       "title",
       "name",
       "description",
-      Set.of("Dark"),
-      "Vendor",
-      "https://example.com",
+      Set.of("tea type"),
+      "vendor",
+      "url",
       "origin",
       "cultivar",
       "season",
       "elevation",
-      "N/A",
+      "price",
       "instructions",
       inStock,
       Set.of()
     ).setId(id);
-  }
-
-  private static TeaEntity entity(long id, boolean inStock) {
-    return new StubTeaEntity(id, inStock);
-  }
-
-  private static class StubTeaEntity extends TeaEntity {
-    private final long id;
-    private final boolean inStock;
-
-    StubTeaEntity(long id, boolean inStock) {
-      this.id = id;
-      this.inStock = inStock;
-    }
-
-    @Override
-    public Long getId() {
-      return id;
-    }
-
-    @Override
-    public boolean isInStock() {
-      return inStock;
-    }
   }
 }


### PR DESCRIPTION
`UpdateTeasAvailability` is a new script that goes through all teas, compares the `inStock` flag in their `info.json` files against Postgres, and updates any rows whose availability has drifted. JSON files are the source of truth — flip `inStock` there and run the script to bring the DB in sync.